### PR TITLE
feat: replace recurrence type with flexible `every_x_days` interval

### DIFF
--- a/modules/Holocron/Grind/Controller/SyncHealthDataController.php
+++ b/modules/Holocron/Grind/Controller/SyncHealthDataController.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Holocron\Grind\Controller;
+
+use Carbon\Carbon;
+use Exception;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
+use Modules\Holocron\Grind\Models\HealthData;
+
+class SyncHealthDataController
+{
+    public function __invoke(Request $request): JsonResponse
+    {
+        try {
+            $validated = $request->validate([
+                'data' => 'required|array',
+                'data.metrics' => 'required|array',
+                'data.metrics.*.name' => 'required|string',
+                'data.metrics.*.units' => 'required|string',
+                'data.metrics.*.data' => 'required|array',
+                'data.metrics.*.data.*.date' => 'required|string',
+                'data.metrics.*.data.*.qty' => 'required|numeric',
+                'data.metrics.*.data.*.source' => 'nullable|string',
+            ]);
+
+            $records = [];
+            $processedCount = 0;
+
+            foreach ($validated['data']['metrics'] as $metric) {
+                $metricName = $metric['name'];
+                $units = $metric['units'];
+
+                foreach ($metric['data'] as $dataPoint) {
+                    $date = Carbon::parse($dataPoint['date'])->toDateString();
+
+                    $records[] = [
+                        'name' => $metricName,
+                        'units' => $units,
+                        'qty' => (float) $dataPoint['qty'],
+                        'date' => $date,
+                        'source' => $dataPoint['source'] ?? null,
+                        'original_payload' => $dataPoint,
+                        'created_at' => now(),
+                        'updated_at' => now(),
+                    ];
+
+                    $processedCount++;
+                }
+            }
+
+            $affectedRows = 0;
+            if (! empty($records)) {
+                DB::transaction(function () use ($records, &$affectedRows) {
+                    $affectedRows = HealthData::query()->upsert(
+                        $records,
+                        ['date', 'name'],
+                        ['qty', 'units', 'source', 'original_payload', 'updated_at']
+                    );
+                });
+            }
+
+            return response()->json([
+                'message' => 'Health data synced successfully',
+                'processed' => $processedCount,
+                'affected_rows' => $affectedRows,
+                'metrics_synced' => count($validated['data']['metrics']),
+            ], 200);
+
+        } catch (ValidationException $e) {
+            return response()->json([
+                'message' => 'Validation failed',
+                'errors' => $e->errors(),
+            ], 422);
+        } catch (Exception $e) {
+            return response()->json([
+                'message' => 'An error occurred while processing health data',
+                'error' => $e->getMessage(),
+            ], 500);
+        }
+    }
+}

--- a/modules/Holocron/Grind/Database/Migrations/2025_10_01_000000_create_grind_health_data_table.php
+++ b/modules/Holocron/Grind/Database/Migrations/2025_10_01_000000_create_grind_health_data_table.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('grind_health_data', function (Blueprint $table): void {
+            $table->id();
+            $table->string('name');
+            $table->string('units');
+            $table->decimal('qty', 10, 2);
+            $table->date('date');
+            $table->string('source')->nullable();
+            $table->json('original_payload');
+            $table->timestamps();
+
+            $table->unique(['date', 'name']);
+        });
+    }
+};

--- a/modules/Holocron/Grind/GrindServiceProvider.php
+++ b/modules/Holocron/Grind/GrindServiceProvider.php
@@ -16,6 +16,7 @@ class GrindServiceProvider extends ServiceProvider
 
         // Load routes
         $this->loadRoutesFrom(__DIR__.'/Routes/web.php');
+        $this->loadRoutesFrom(__DIR__.'/Routes/api.php');
 
         // Load views and assign namespace 'order'
         $this->loadViewsFrom(__DIR__.'/Views', 'holocron-grind');

--- a/modules/Holocron/Grind/Livewire/HealthData.php
+++ b/modules/Holocron/Grind/Livewire/HealthData.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Holocron\Grind\Livewire;
+
+use Illuminate\View\View;
+use Livewire\Attributes\Title;
+use Livewire\WithPagination;
+use Modules\Holocron\_Shared\Livewire\HolocronComponent;
+use Modules\Holocron\Grind\Models\HealthData as HealthDataModel;
+
+#[Title('Health Data')]
+class HealthData extends HolocronComponent
+{
+    use WithPagination;
+
+    public function render(): View
+    {
+        return view('holocron-grind::health-data', [
+            'entries' => HealthDataModel::query()->latest('date')->latest('id')->paginate(100),
+            'count' => HealthDataModel::query()->count(),
+        ]);
+    }
+}

--- a/modules/Holocron/Grind/Models/HealthData.php
+++ b/modules/Holocron/Grind/Models/HealthData.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Holocron\Grind\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class HealthData extends Model
+{
+    protected $table = 'grind_health_data';
+
+    protected function casts(): array
+    {
+        return [
+            'date' => 'date',
+            'original_payload' => 'array',
+            'qty' => 'decimal:2',
+        ];
+    }
+}

--- a/modules/Holocron/Grind/Routes/api.php
+++ b/modules/Holocron/Grind/Routes/api.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Middleware\BearerToken;
+use Illuminate\Support\Facades\Route;
+use Modules\Holocron\Grind\Controller\SyncHealthDataController;
+
+Route::middleware(BearerToken::class)
+    ->name('holocron.grind.')
+    ->prefix('api/holocron/grind')
+    ->group(function () {
+        Route::post('/health', SyncHealthDataController::class)->name('health.sync');
+    });

--- a/modules/Holocron/Grind/Routes/web.php
+++ b/modules/Holocron/Grind/Routes/web.php
@@ -13,4 +13,6 @@ Route::middleware(['web', 'auth'])->name('holocron.')->prefix('holocron/grind')-
     Route::get('/plans/{plan}', Livewire\Plans\Show::class)->name('grind.plans.show');
     Route::get('/workouts', Livewire\Workouts\Index::class)->name('grind.workouts.index');
     Route::get('/workouts/{workout}', Livewire\Workouts\Show::class)->name('grind.workouts.show');
+
+    Route::get('/health-data', Livewire\HealthData::class)->name('grind.health-data');
 });

--- a/modules/Holocron/Grind/Views/health-data.blade.php
+++ b/modules/Holocron/Grind/Views/health-data.blade.php
@@ -1,0 +1,32 @@
+@use(Illuminate\Support\Number)
+
+<div class="space-y-4">
+    <flux:heading size="xl">
+        {{ Number::format(number: $count, locale: 'de-DE') }} Health Records
+    </flux:heading>
+
+    <div class="space-y-1">
+        @foreach($entries as $entry)
+            <div class="flex justify-between items-center">
+                <div class="font-mono">{{ $entry->date->format('d.m.Y') }}</div>
+                <div class="flex-1 ml-4">
+                    <span class="font-medium">{{ $entry->name }}:</span>
+                    <span>{{ $entry->qty }} {{ $entry->units }}</span>
+                </div>
+                <div class="font-mono text-sm text-gray-600">
+                    {{ $entry->source ?? 'Unknown' }}
+                </div>
+            </div>
+        @endforeach
+
+        @if($entries->isEmpty())
+            <div class="text-center py-8 text-gray-500">
+                No health data records found.
+            </div>
+        @endif
+    </div>
+
+    @if($entries->hasPages())
+        <flux:pagination :paginator="$entries" />
+    @endif
+</div>

--- a/modules/Holocron/Grind/Views/navigation.blade.php
+++ b/modules/Holocron/Grind/Views/navigation.blade.php
@@ -2,4 +2,5 @@
     <flux:navbar.item href="{{ route('holocron.grind.workouts.index') }}" wire:navigate>Workouts</flux:navbar.item>
     <flux:navbar.item href="{{ route('holocron.grind.exercises.index') }}" wire:navigate>Übungen</flux:navbar.item>
     <flux:navbar.item href="{{ route('holocron.grind.plans.index') }}" wire:navigate>Pläne</flux:navbar.item>
+    <flux:navbar.item href="{{ route('holocron.grind.health-data') }}" wire:navigate>Health Data</flux:navbar.item>
 </flux:navbar>


### PR DESCRIPTION
- Refactored recurrence system to use `every_x_days` instead of predefined types (`daily`, `weekly`, `monthly`).
- Removed the `QuestRecurrenceType` enum and replaced `type` and `value` columns with `every_x_days` in `quest_recurrences` table.
- Updated frontend recurrence modal to support custom day intervals.
- Adjusted recurrence logic and tests to handle the new interval-based recurrence.
- Added migration to transform existing data and maintain compatibility.